### PR TITLE
handle invalid credentials

### DIFF
--- a/src/routes/(auth)/login/+page.server.ts
+++ b/src/routes/(auth)/login/+page.server.ts
@@ -1,5 +1,5 @@
 import { fail, redirect } from '@sveltejs/kit'
-import { superValidate } from 'sveltekit-superforms/server'
+import { superValidate, setError } from 'sveltekit-superforms/server'
 
 import { auth } from '$lib/server/auth'
 import { authSchema } from '$lib/zod/schema'
@@ -32,7 +32,7 @@ export const actions = {
 			const session = await auth.createSession(key.userId)
 			locals.setSession(session)
 		} catch (error) {
-			return fail(400)
+			return setError(form, 'username', 'Invalid credentials!')
 		}
 	},
 }

--- a/src/routes/(auth)/register/+page.server.ts
+++ b/src/routes/(auth)/register/+page.server.ts
@@ -1,5 +1,5 @@
 import { fail, redirect } from '@sveltejs/kit'
-import { superValidate } from 'sveltekit-superforms/server'
+import { superValidate, setError } from 'sveltekit-superforms/server'
 
 import { auth } from '$lib/server/auth'
 import { authSchema } from '$lib/zod/schema'
@@ -37,8 +37,7 @@ export const actions = {
 			const session = await auth.createSession(user.userId)
 			locals.setSession(session)
 		} catch (error) {
-			// username already in use
-			return fail(400)
+			return setError(form, 'username', 'Username already in use')
 		}
 	},
 }


### PR DESCRIPTION
Currently, invalid credentials are not handled, so users cannot know what went wrong.
This returns an Invalid credentials error for failed login attempts.

https://github.com/ciscoheat/sveltekit-superforms/wiki/API-reference#seterrorform-field-error-options